### PR TITLE
Updated github label to use backticks

### DIFF
--- a/config/triggers/github/notify_when_labels_are_added_or_removed_from_a_pull_request.rb
+++ b/config/triggers/github/notify_when_labels_are_added_or_removed_from_a_pull_request.rb
@@ -3,7 +3,7 @@ Houston.config do
     channel = "##{pull_request.project.slug}"
     channel = "developers-only" unless Houston::Slack.connection.channels.include? channel
 
-    message = "#{pull_request.actor || "Someone"} removed *#{label}* from #{slack_link_to_pull_request(pull_request)}"
+    message = "#{pull_request.actor || "Someone"} removed `#{label}` from #{slack_link_to_pull_request(pull_request)}"
 
     slack_send_message_to message, channel, as: :github
   end


### PR DESCRIPTION
Forgot to change it for when labels are removed. 